### PR TITLE
add: settings vm.max_map_count ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,13 @@ then
     sudo sysctl -w vm.max_map_count=262144
 fi
 
+if [ "$OS" = "Ubuntu" ]
+then
+    echo "Setting vm.max_map_count for Linux Ubuntu"
+    sudo sysctl -w vm.max_map_count=262144
+fi
+
+
 if [ "$OS" = "Darwin" ]
 then
     echo "Happy to have a Mac"


### PR DESCRIPTION
When i tried to install Fairlytics on my Ubuntu. I get this error:

"max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]"

So in the install.sh i added few lines for set this settings on ubuntu